### PR TITLE
Fix SRAM size determination

### DIFF
--- a/GB Memory/Main.cs
+++ b/GB Memory/Main.cs
@@ -165,6 +165,8 @@ namespace GB_Memory
             ROMListPanel.Controls.Add(ROMPanel);
             ROMList.Add(ROMToAdd);
             updateROMSpace();
+
+            ShowRAMSizeOverflowWarning(ROMToAdd);
         }
 
         private void AddButtonClick(object sender, EventArgs e)
@@ -314,6 +316,7 @@ namespace GB_Memory
                             ROMToProcess = Processing.ParseROM(Mem, GenerateFor.FileName);
                         }
                     }
+                    ShowRAMSizeOverflowWarning(ROMToProcess);
 
                     Byte[] MAPBytes = Processing.GenerateStandaloneMAPForROM(ROMToProcess);
 
@@ -428,6 +431,14 @@ namespace GB_Memory
             else
             {
                 e.Effect = DragDropEffects.None;
+            }
+        }
+
+        private void ShowRAMSizeOverflowWarning(ROM R)
+        {
+            if (R.IsRAMSizeOverflow)
+            {
+                MessageBox.Show("GB Memory doesn't support ROMs with more than 32kBytes of SRAM, your ROM will not work correctly.", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
         }
     }

--- a/GB Memory/Processing.cs
+++ b/GB Memory/Processing.cs
@@ -165,9 +165,9 @@ namespace GB_Memory
                     //8KB
                     Bits[9] = false; Bits[8] = true; Bits[7] = false;
                 }
-                else if (ROMToProcess.RAMSizeKByte == 32)
+                else if (ROMToProcess.RAMSizeKByte >= 32)
                 {
-                    //32KB
+                    //32KB or bigger (but we can use <= 4 blocks (32KB) of SRAM per one ROM)
                     Bits[9] = false; Bits[8] = true; Bits[7] = true;
                 }
                 else
@@ -310,9 +310,9 @@ namespace GB_Memory
                         //8KB
                         Bits[9] = false; Bits[8] = true; Bits[7] = false;
                     }
-                    else if (ROMList[i].RAMSizeKByte == 32)
+                    else if (ROMList[i].RAMSizeKByte >= 32)
                     {
-                        //32KB
+                        //32KB or bigger (but we can use <= 4 blocks (32KB) of SRAM per one ROM)
                         Bits[9] = false; Bits[8] = true; Bits[7] = true;
                     }
                     else

--- a/GB Memory/Processing.cs
+++ b/GB Memory/Processing.cs
@@ -150,15 +150,15 @@ namespace GB_Memory
                 }
 
                 //SRAM Size
-                if (ROMToProcess.RAMSizeKByte == 0)
+                if (ROMToProcess.CartridgeType == 0x6)
+                {
+                    //MBC2+BATTERY
+                    Bits[9] = false; Bits[8] = false; Bits[7] = true;
+                }
+                else if (ROMToProcess.RAMSizeKByte == 0)
                 {
                     //No SRAM
                     Bits[9] = false; Bits[8] = false; Bits[7] = false;
-                }
-                else if (ROMToProcess.CartridgeType >= 0x5 && ROMToProcess.CartridgeType <= 0x6)
-                {
-                    //MBC2
-                    Bits[9] = false; Bits[8] = false; Bits[7] = true;
                 }
                 else if (ROMToProcess.RAMSizeKByte == 8)
                 {
@@ -295,15 +295,15 @@ namespace GB_Memory
                     }
 
                     //SRAM Size
-                    if (ROMList[i].RAMSizeKByte == 0)
+                    if (ROMList[i].CartridgeType == 0x6)
+                    {
+                        //MBC2+BATTERY
+                        Bits[9] = false; Bits[8] = false; Bits[7] = true;
+                    }
+                    else if (ROMList[i].RAMSizeKByte == 0)
                     {
                         //No SRAM
                         Bits[9] = false; Bits[8] = false; Bits[7] = false;
-                    }
-                    else if (ROMList[i].CartridgeType >= 0x5 && ROMList[i].CartridgeType <= 0x6)
-                    {
-                        //MBC2
-                        Bits[9] = false; Bits[8] = false; Bits[7] = true;
                     }
                     else if (ROMList[i].RAMSizeKByte == 8)
                     {
@@ -334,7 +334,7 @@ namespace GB_Memory
 
                     //RAM Offset
                     Mem.WriteByte((Byte)(RAMStartOffset / 2));
-                    RAMStartOffset += ROMList[i].RAMSizeKByte;
+                    RAMStartOffset += ((ROMList[i].CartridgeType == 0x6 || ROMList[i].RAMSizeKByte < 8) ? 8 : ROMList[i].RAMSizeKByte);
                 }
 
                 while (Mem.Position < 0x6E)

--- a/GB Memory/ROM.cs
+++ b/GB Memory/ROM.cs
@@ -27,6 +27,13 @@ namespace GB_Memory
                 return (2 * (int)Math.Pow(4,RAMSize-1));
             }
         }
+        public bool IsRAMSizeOverflow
+        {
+            get
+            {
+                return (RAMSizeKByte > 32);
+            }
+        }
         public String CartridgeTypeString
         {
             get


### PR DESCRIPTION
- Fix RAM Size for MBC2+BATTERY.
- Fix RAM Start Offset to be aligned to an 8KB block boundary.
- Assign 32KB RAM for RAMSize larger than 32KB.
  - It works with LSDj ROM (1024KB ROM+128KB RAM; but works with 32KB RAM with some limitations)
  - Show a warning when add a ROM (with RAM > 32KB) to interface.
